### PR TITLE
Fix null ref in MemoryReviewSettingsSource

### DIFF
--- a/src/ReviewService.Abstractions/ReviewService.Abstractions.csproj
+++ b/src/ReviewService.Abstractions/ReviewService.Abstractions.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<LangVersion>10.0</LangVersion>
+		<Nullable>enable</Nullable>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<Authors>nventive</Authors>
 		<Company>nventive</Company>

--- a/src/ReviewService.NativePrompters/ReviewPrompter.Android.cs
+++ b/src/ReviewService.NativePrompters/ReviewPrompter.Android.cs
@@ -12,7 +12,7 @@ namespace ReviewService;
 /// </summary>
 public sealed class ReviewPrompter : IReviewPrompter, IDisposable
 {
-	private readonly Android.OS.Handler _handler = new(Android.OS.Looper.MainLooper);
+	private readonly Android.OS.Handler _handler = new(Android.OS.Looper.MainLooper!);
 
 	private readonly ILogger _logger;
 
@@ -20,7 +20,7 @@ public sealed class ReviewPrompter : IReviewPrompter, IDisposable
 	/// Initializes a new instance of the <see cref="ReviewPrompter"/> class.
 	/// </summary>
 	/// <param name="logger">The service logger.</param>
-	public ReviewPrompter(ILogger<ReviewPrompter> logger)
+	public ReviewPrompter(ILogger<ReviewPrompter>? logger)
 	{
 		_logger = logger ?? NullLogger<ReviewPrompter>.Instance;
 	}

--- a/src/ReviewService.NativePrompters/ReviewPrompter.Windows.cs
+++ b/src/ReviewService.NativePrompters/ReviewPrompter.Windows.cs
@@ -16,7 +16,7 @@ public class ReviewPrompter : IReviewPrompter
 	/// Initializes a new instance of the <see cref="ReviewPrompter"/> class.
 	/// </summary>
 	/// <param name="logger">The service logger.</param>
-	public ReviewPrompter(ILogger<ReviewPrompter> logger)
+	public ReviewPrompter(ILogger<ReviewPrompter>? logger)
 	{
 		_logger = logger ?? NullLogger<ReviewPrompter>.Instance;
 	}

--- a/src/ReviewService.NativePrompters/ReviewPrompter.iOS.cs
+++ b/src/ReviewService.NativePrompters/ReviewPrompter.iOS.cs
@@ -18,7 +18,7 @@ public sealed class ReviewPrompter : IReviewPrompter
 	/// Initializes a new instance of the <see cref="ReviewPrompter"/> class.
 	/// </summary>
 	/// <param name="logger">The service logger.</param>
-	public ReviewPrompter(ILogger<ReviewPrompter> logger)
+	public ReviewPrompter(ILogger<ReviewPrompter>? logger)
 	{
 		_logger = logger ?? NullLogger<ReviewPrompter>.Instance;
 	}

--- a/src/ReviewService.NativePrompters/ReviewService.NativePrompters.csproj
+++ b/src/ReviewService.NativePrompters/ReviewService.NativePrompters.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<LangVersion>10.0</LangVersion>
+		<Nullable>enable</Nullable>
 		<TargetFrameworks>net6.0;net6.0-android;net6.0-ios;net6.0-windows10.0.19041</TargetFrameworks>
 		<Authors>nventive</Authors>
 		<Company>nventive</Company>

--- a/src/ReviewService.Tests/MemoryReviewSettingsSourceShould.cs
+++ b/src/ReviewService.Tests/MemoryReviewSettingsSourceShould.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ReviewService.Tests;
+
+public sealed class MemoryReviewSettingsSourceShould
+{
+	[Fact]
+	public async Task Not_return_null_when_reading_from_a_new_instance()
+	{
+		// Arrange
+		var source = new MemoryReviewSettingsSource<ReviewSettings>();
+		var cancellationToken = new CancellationToken();
+
+		// Act
+		var result = await source.Read(cancellationToken);
+
+		// Assert
+		Assert.NotNull(result);
+	}
+
+	[Fact]
+	public async Task Return_the_same_value_that_was_written_when_reading()
+	{
+		// Arrange
+		var source = new MemoryReviewSettingsSource<ReviewSettings>();
+		var cancellationToken = new CancellationToken();
+		var value = new ReviewSettings
+		{
+			RequestCount = 10
+		};
+
+		await source.Write(cancellationToken, value);
+		
+		// Act
+		var result = await source.Read(cancellationToken);
+
+		// Assert
+		Assert.Equal(value, result);
+	}
+}

--- a/src/ReviewService/LoggingReviewPrompter.cs
+++ b/src/ReviewService/LoggingReviewPrompter.cs
@@ -15,7 +15,7 @@ public sealed class LoggingReviewPrompter : IReviewPrompter
 	/// Initializes a new instance of the <see cref="LoggingReviewPrompter"/> class.
 	/// </summary>
 	/// <param name="logger">The logger in which to log the <see cref="TryPrompt"/> invocation.</param>
-	public LoggingReviewPrompter(ILogger<LoggingReviewPrompter> logger)
+	public LoggingReviewPrompter(ILogger<LoggingReviewPrompter>? logger)
 	{
 		_logger = logger ?? NullLogger<LoggingReviewPrompter>.Instance;
 	}

--- a/src/ReviewService/MemoryReviewSettingsSource.cs
+++ b/src/ReviewService/MemoryReviewSettingsSource.cs
@@ -8,9 +8,9 @@ namespace ReviewService;
 /// </summary>
 /// <typeparam name="TReviewSettings">The type of the persisted object.</typeparam>
 public sealed class MemoryReviewSettingsSource<TReviewSettings> : IReviewSettingsSource<TReviewSettings>
-	where TReviewSettings : ReviewSettings
+	where TReviewSettings : ReviewSettings, new()
 {
-	private TReviewSettings _reviewSettings = default;
+	private TReviewSettings _reviewSettings = new TReviewSettings();
 
 	/// <inheritdoc/>
 	public Task<TReviewSettings> Read(CancellationToken ct)

--- a/src/ReviewService/ReviewService.cs
+++ b/src/ReviewService/ReviewService.cs
@@ -28,10 +28,10 @@ public sealed class ReviewService<TReviewSettings> : IReviewService<TReviewSetti
 	/// <param name="reviewSettingsSource">The review settings source (Read and write).</param>
 	/// <param name="reviewConditionsBuilder">The review conditions builder.</param>
 	public ReviewService(
-		ILogger<ReviewService<TReviewSettings>> logger,
+		ILogger<ReviewService<TReviewSettings>>? logger,
 		IReviewPrompter reviewPrompter,
 		IReviewSettingsSource<TReviewSettings> reviewSettingsSource,
-		IReviewConditionsBuilder<TReviewSettings> reviewConditionsBuilder
+		IReviewConditionsBuilder<TReviewSettings>? reviewConditionsBuilder
 	)
 	{
 		_logger = logger ?? NullLogger<ReviewService<TReviewSettings>>.Instance;

--- a/src/ReviewService/ReviewService.csproj
+++ b/src/ReviewService/ReviewService.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<LangVersion>10.0</LangVersion>
+		<Nullable>enable</Nullable>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<Authors>nventive</Authors>
 		<Company>nventive</Company>


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [x] Documentation content changes
 - [ ] Other, please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

Null ref when first using `MemoryReviewSettingsSource`.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

- No null ref when first using `MemoryReviewSettingsSource`.
- Also added recommendations in readme around dependency injection and usage.
- Enable `Nullable` on each csproj.


## Checklist

Please check that your PR fulfills the following requirements:

- [x] Documentation has been added/updated.
- [x] Automated tests for the changes have been added/updated.
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

