### PR TITLE
chore!: Update .NET 10

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -10,6 +10,9 @@ Example:
   - `This` was renamed to `That`.
 -->
 
+## 4.0.0
+  - Update .NET Target From 8 To 10.
+
 ## 3.0.0
   - The 'IReviewService.TryRequestReview' now returns a result.
 

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
 - name: NUGET_VERSION
   value: 6.2.0
 - name: windowsHostedAgentImage
-  value: 'windows-2022'
+  value: 'windows-2025'
 - name: ArtifactName
   value: Packages
 - name: SolutionFileName

--- a/build/stage-build.yml
+++ b/build/stage-build.yml
@@ -1,7 +1,7 @@
 ﻿parameters:
-  DotNetVersion: '8.0.401'
-  UnoCheck_Version: '1.30.1'
-  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/0ca039bef4097295fc6c2c5c282ae18a797160c1/manifests/uno.ui.manifest.json'
+  DotNetVersion: '10.0.100'
+  UnoCheck_Version: '1.33.1'
+  UnoCheck_Manifest: 'https://raw.githubusercontent.com/unoplatform/uno.check/3bd81468f842eb34fe4760d1694baf8e4ba6edba/manifests/uno.ui.manifest.json'
 
 steps:
 - task: GitVersion/setup@0

--- a/src/ReviewService.Abstractions/ReviewService.Abstractions.csproj
+++ b/src/ReviewService.Abstractions/ReviewService.Abstractions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<LangVersion>12.0</LangVersion>
+		<LangVersion>14.0</LangVersion>
 		<Nullable>enable</Nullable>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<Authors>nventive</Authors>
@@ -16,7 +16,7 @@
 		<RootNamespace>ReviewService</RootNamespace>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
-	
+
 	<ItemGroup>
 		<None Include="..\..\README.md">
 			<Pack>True</Pack>

--- a/src/ReviewService.NativePrompters/ReviewService.NativePrompters.csproj
+++ b/src/ReviewService.NativePrompters/ReviewService.NativePrompters.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<LangVersion>12.0</LangVersion>
+		<LangVersion>14.0</LangVersion>
 		<Nullable>enable</Nullable>
-		<TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-windows10.0.20348.0</TargetFrameworks>
+		<TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net10.0-windows10.0.20348.0</TargetFrameworks>
 		<Authors>nventive</Authors>
 		<Company>nventive</Company>
 		<AssemblyName>ReviewService.NativePrompters</AssemblyName>
@@ -38,7 +38,7 @@
 		<PackageReference Include="Plugin.StoreReview" Version="6.2.0" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)'=='net8.0-windows10.0.19041.38'">
+	<ItemGroup Condition="'$(TargetFramework)'=='net10.0-windows10.0.20348.0'">
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250606001" />
 	</ItemGroup>
 

--- a/src/ReviewService.Tests/ReviewService.Tests.csproj
+++ b/src/ReviewService.Tests/ReviewService.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<LangVersion>12.0</LangVersion>
-		<TargetFramework>net8.0</TargetFramework>
+		<LangVersion>14.0</LangVersion>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>

--- a/src/ReviewService/ReviewService.csproj
+++ b/src/ReviewService/ReviewService.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<LangVersion>12.0</LangVersion>
+		<LangVersion>14.0</LangVersion>
 		<Nullable>enable</Nullable>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<Authors>nventive</Authors>
@@ -16,7 +16,7 @@
 		<RootNamespace>ReviewService</RootNamespace>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
-	
+
 	<ItemGroup>
 		<None Include="..\..\README.md">
 			<Pack>True</Pack>


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [x] Build or CI related changes
 - [ ] Documentation content changes
 - [x] Other, please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->

Targets .NET 8.
Uses C# 12.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->

Targets .NET 10.
Uses C# 14.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [x] **Major** (Public API was modified.)
  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
  - Public members were removed or renamed.
  - Public method signatures were changed or renamed.
- [ ] **Minor** (Public API was extended.)
  - Public constructs, members, or overloads were added.
- [ ] **Patch** (Public API was unchanged.)
  - A bug in behavior was fixed.
  - Documentation was changed.
- [ ] **None** (The library is unchanged.)
  - Only code under the `build` folder was changed.
  - Only code under the `.github` folder was changed.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] ~~Documentation has been added/updated.~~
- [ ] ~~Automated Unit / Integration tests for the changes have been added/updated.~~
- [x] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
- [x] Your conventional commits are aligned with the **Impact on version** section.

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

